### PR TITLE
Ref: Downgrade sprockets gem to pre-4.0

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -51,7 +51,7 @@ jobs:
           bundler-cache: true
       # Add or replace any other lints here
       - name: Security audit dependencies
-        run: bundler-audit --update
+        run: bundle exec bundler-audit --update
       - name: Security audit application code
         run: bin/brakeman -q -w2
       - name: Lint Ruby files

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -51,7 +51,7 @@ jobs:
           bundler-cache: true
       # Add or replace any other lints here
       - name: Security audit dependencies
-        run: bin/bundler-audit --update
+        run: bundler-audit --update
       - name: Security audit application code
         run: bin/brakeman -q -w2
       - name: Lint Ruby files

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -53,6 +53,6 @@ jobs:
       - name: Security audit dependencies
         run: bundle exec bundler-audit --update
       - name: Security audit application code
-        run: bin/brakeman -q -w2
+        run: bundle exec brakeman -q -w2
       - name: Lint Ruby files
-        run: bin/rubocop --parallel
+        run: bundle exec rubocop --parallel

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '~> 5.2.8'
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
 # Use Puma as the app server
-gem 'puma', '~> 3.11'
+gem 'puma',  '~> 4.3.9'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem 'brakeman'
 
 gem 'rubocop-rails', require: false
 
+gem 'bundler-audit'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,10 @@ gem 'rack-cors'
 
 gem 'sprockets', '< 4'
 
+gem 'brakeman'
+
+gem 'rubocop', '~> 1.31', require: false
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -28,10 +28,11 @@ gem 'jsonapi-serializer'
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors'
 
+gem 'sprockets', '< 4'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'graphiql-rails'
   gem 'factory_bot_rails'
   gem "faker"
   gem 'pry'
@@ -44,11 +45,12 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'graphiql-rails'
 end
 group :test do
   gem 'rspec-rails'
   gem 'simplecov'
-  
+
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'sprockets', '< 4'
 
 gem 'brakeman'
 
-gem 'rubocop', '~> 1.31', require: false
+gem 'rubocop-rails', require: false
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,8 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    puma (3.12.6)
+    puma (4.3.12)
+      nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.4)
     rack-cors (1.1.1)
@@ -225,7 +226,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry
-  puma (~> 3.11)
+  puma (~> 4.3.9)
   rack-cors
   rails (~> 5.2.8)
   rspec-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,10 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.19.1)
       parser (>= 3.1.1.0)
+    rubocop-rails (2.15.2)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.7.0, < 2.0)
     ruby-progressbar (1.11.0)
     ruby_dep (1.5.0)
     shoulda-matchers (5.1.0)
@@ -221,7 +225,7 @@ DEPENDENCIES
   rack-cors
   rails (~> 5.2.8)
   rspec-rails
-  rubocop (~> 1.31)
+  rubocop-rails
   shoulda-matchers
   simplecov
   spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
       railties
       sprockets-rails
     graphql (2.0.11)
-    i18n (1.10.0)
+    i18n (1.11.0)
       concurrent-ruby (~> 1.0)
     jsonapi-serializer (2.2.0)
       activesupport (>= 4.2)
@@ -93,8 +93,6 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
-      racc (~> 1.4)
-    nokogiri (1.13.6-x86_64-darwin)
       racc (~> 1.4)
     pg (1.4.1)
     pry (0.14.1)
@@ -165,7 +163,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (4.1.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.4.2)
@@ -182,7 +180,6 @@ GEM
 
 PLATFORMS
   ruby
-  x86_64-darwin-21
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)
@@ -204,10 +201,11 @@ DEPENDENCIES
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
+  sprockets (< 4)
   tzinfo-data
 
 RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.3.11
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,8 +43,10 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (9.0.0)
+    ast (2.4.2)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
+    brakeman (5.2.3)
     builder (3.2.4)
     byebug (11.1.3)
     coderay (1.1.3)
@@ -73,6 +75,7 @@ GEM
     graphql (2.0.11)
     i18n (1.11.0)
       concurrent-ruby (~> 1.0)
+    json (2.6.2)
     jsonapi-serializer (2.2.0)
       activesupport (>= 4.2)
     listen (3.1.5)
@@ -94,6 +97,9 @@ GEM
     nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    parallel (1.22.1)
+    parser (3.1.2.0)
+      ast (~> 2.4.1)
     pg (1.4.1)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -129,10 +135,13 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
+    rainbow (3.1.1)
     rake (13.0.6)
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    regexp_parser (2.5.0)
+    rexml (3.2.5)
     rspec-core (3.11.0)
       rspec-support (~> 3.11.0)
     rspec-expectations (3.11.0)
@@ -150,6 +159,19 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.11.0)
+    rubocop (1.31.2)
+      json (~> 2.3)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.18.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.19.1)
+      parser (>= 3.1.1.0)
+    ruby-progressbar (1.11.0)
     ruby_dep (1.5.0)
     shoulda-matchers (5.1.0)
       activesupport (>= 5.2.0)
@@ -174,6 +196,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
+    unicode-display_width (2.2.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -183,6 +206,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)
+  brakeman
   byebug
   database_cleaner-active_record
   factory_bot_rails
@@ -197,6 +221,7 @@ DEPENDENCIES
   rack-cors
   rails (~> 5.2.8)
   rspec-rails
+  rubocop (~> 1.31)
   shoulda-matchers
   simplecov
   spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,9 @@ GEM
       msgpack (~> 1.2)
     brakeman (5.2.3)
     builder (3.2.4)
+    bundler-audit (0.9.1)
+      bundler (>= 1.2.0, < 3)
+      thor (~> 1.0)
     byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
@@ -211,6 +214,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   brakeman
+  bundler-audit
   byebug
   database_cleaner-active_record
   factory_bot_rails


### PR DESCRIPTION
____ Wrote Tests
__x__ Implemented
____ Reviewed


## Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally

## Type of change
- [] New feature
- [x] Bug Fix

## Implements/Fixes:
* `sprockets` is a gem dependency for `graphql`, however version 4.0 + induces a bug in conjunction with graphql in the Heroku build phase. To avoid this, I've simply specified the version `< 4` in our Gemfile, which has pulled 3.7.2 into our lock file. This should not affect any other functionality within our code, all tests are still passing. 

## Check the correct boxes
- [x] This broke nothing
- [x] All Tests are Passing
- [x] The code will run locally

## Testing Changes
- [] Tests have been added
- [x] No Tests have been changed
- [] Some Tests have been changed
- [] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have fully tested my code
- [] I have removed any testing syntax (save_and_open_page/pry) in my spec files

## Please include a link to a gif of how you feel about this branch:

![are-you-serious-spiderman](https://user-images.githubusercontent.com/70451678/178167642-58982d6f-5028-4e4e-884c-60b62e0d8394.gif)

