### PR TITLE
Fix: use interpolation on fetch skill spec to avoid error

### DIFF
--- a/spec/graphql/queries/fetch_skill_spec.rb
+++ b/spec/graphql/queries/fetch_skill_spec.rb
@@ -6,7 +6,7 @@ module Queries
             it 'returns a skill with the given id' do 
                 sit = Skill.create!(name: "Sit", level: 1, description: 'Step 1. Get your dogs attention with a treat. 2. While raising your hand upwards, say "sit". 3. Your dog should sit and look at you. 4. Reward your dog with the treat.', criteria: "Your dog should sit right as you are saying the command, and stay sitting until you release them", youtube_link: "https://www.youtube.com/watch?v=EDgi2sLlWAU")
                 
-                post '/graphql', params: { query: query }
+                post '/graphql', params: { query: query(sit.id) }
                 json = JSON.parse(response.body, symbolize_names: true)
                 data = json[:data][:fetchSkill]
 
@@ -44,10 +44,10 @@ module Queries
             end
         end  
         
-        def query
+        def query(id)
             <<~GQL
                 query {
-                    fetchSkill(id: 1) {
+                    fetchSkill(id: #{id}) {
                         name
                         level
                         description


### PR DESCRIPTION
_AP__ Wrote Tests
____ Implemented
____ Reviewed


## Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally

## Type of change
- [] New feature
- [x] Bug Fix

## Implements/Fixes:
* Fixed fetch skill spec to use interpolation in the query instead of hard-coding skill id. 

## Check the correct boxes
- [x] This broke nothing
- [x] All Tests are Passing
- [x] The code will run locally

## Testing Changes
- [] Tests have been added
- [] No Tests have been changed
- [x] Some Tests have been changed
- [] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
- [] I have removed any testing syntax (save_and_open_page/pry) in my spec files

## Please include a link to a gif of how you feel about this branch:
feelsgoodman.gif